### PR TITLE
Install gcc

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -25,8 +25,7 @@ echo -n "Uninstalling old Ruby and Puppet"
 yum remove -y ruby-* puppet-*
 
 echo -n "Installing Ruby"
-progress_bar yum install -y https://s3-eu-west-1.amazonaws.com/msm-public-repo/ruby/ruby-2.1.5-2.el6.x86_64.rpm augeas-devel
-progress_bar yum install -y ncurses-devel
+progress_bar yum install -y https://s3-eu-west-1.amazonaws.com/msm-public-repo/ruby/ruby-2.1.5-2.el6.x86_64.rpm augeas-devel ncurses-devel gcc
 
 echo -n "Installing curl"
 progress_bar yum install -y curl


### PR DESCRIPTION
Newer AMIs don't have the gcc package required to compile ruby-augeas