### PR TITLE
Fix bug in report of top 10 slowest resources

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -494,7 +494,7 @@ run_puppet() {
   echo "===============-Top 10 slowest Puppet resources-==============="
   for i in ${PERFORMANCE_DATA[*]}; do
     echo -n "${i}s - "
-    echo "$(grep -B 3 "$i" /var/lib/puppet/reports/*/*.yaml | head -1 | awk '{print $2 $3}' )"
+    echo "$(grep -B 3 "evaluation_time: $i" /var/lib/puppet/reports/*/*.yaml | head -1 | awk '{print $2 $3}' )"
   done | tac
   echo "===============-Top 10 slowest Puppet resources-==============="
 }


### PR DESCRIPTION
The former `grep` search string was retrieving undesired lines because some evaluation times may appear more than once in the yaml file (but only one of these lines is the desired one that begins with 'evaluation_time: ').

Below is a test comparing the output of the former command with the new one:
will@skami ~ $ `PUPPET_LOG=$(find ~/Downloads -name '*201709280342*' )`
will@skami ~ $ `PERFORMANCE_DATA=( $(grep evaluation_time "${PUPPET_LOG}" | awk '{print $2}'` | sort -n | tail -10 ) )
will@skami ~ $ `for i in ${PERFORMANCE_DATA[*]}; do     echo -n "${i}s - ";     echo "$(grep -B 3 "$i" $PUPPET_LOG | head -1 | awk '{print $2 $3}' )";   done`
10.523449027s - Exec[compile-s3fs]
13.02991107s - 0.31539467
21.45853728s - Package[aws-sdk]
25.736191973s - "Exec[PermitIPsec
25.921703715s - "Exec[PermitIPsec
29.251348051s - Install_package[aem-hotfixes/cq-5.6.1-service-pack-2.1.0.zip]
30.249172744s - 0.012369064999999999
38.743460388s - Package[nokogiri]
337.388410859s - Exec[restore]
1034.285516656s - 30.249172744
will@skami ~ $ `for i in ${PERFORMANCE_DATA[*]}; do     echo -n "${i}s - ";     echo "$(grep -B 3 "evaluation_time: $i" $PUPPET_LOG | head -1 | awk '{print $2 $3}' )";   done`
10.523449027s - Exec[compile-s3fs]
13.02991107s - Filesystem[/dev/lvm-data01/data01]
21.45853728s - Package[aws-sdk]
25.736191973s - "Exec[PermitIPsec
25.921703715s - "Exec[PermitIPsec
29.251348051s - Install_package[aem-hotfixes/cq-5.6.1-service-pack-2.1.0.zip]
30.249172744s - Aem_password[admin]
38.743460388s - Package[nokogiri]
337.388410859s - Exec[restore]
1034.285516656s - Bundle[aem-hotfixes/cq-5.6.1-service-pack-2.1.0.zip_installed]