### PR TITLE
Fix removal of packer installed copy of hiera gem

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -325,7 +325,7 @@ install_gem_deps() {
   gem_install unversioned_gem_manifest:1.0.0
   # Default in /tmp may be unreadable for systems that overmount /tmp (AEM)
   export RUBYGEMS_UNVERSIONED_MANIFEST=/var/log/unversioned_gems.yaml  
-  gem_install puppet:3.8.7 hiera facter 'ruby-augeas:~>0.5' 'hiera-eyaml:~>2.1' 'ruby-shadow:~>2.5' facter_ipaddress_primary:1.1.0
+  gem_install puppet:3.8.7 'hiera:~>3.4' facter 'ruby-augeas:~>0.5' 'hiera-eyaml:~>2.1' 'ruby-shadow:~>2.5' facter_ipaddress_primary:1.1.0
   # Configure facter_ipaddress_primary so it works outside this script.
   # i.e Users logging in interactively can run puppet apply successfully
   echo 'export FACTERLIB="${FACTERLIB}:$(ipaddress_primary_path)"'>/etc/profile.d/ipaddress_primary.sh


### PR DESCRIPTION
Fix removal of packer installed copy of hiera gem by ruby uninstall and subsequent failure to install because puppet required version is present.

Background.

Newer Ruby than packer shipped version triggers removal of old Ruby and of course gems
Packer had previously installed hiera 3.4
When puppet installs it installs hiera 1.3.4 and with previous logic this matched the install check so hiera 3.4 is not re-added if removed.
Hiera 3.4 happens to be needed for command line to look up hash keys in ci1 scripts.